### PR TITLE
feat(bin): convert string "files" prop to array; use "dist" as default output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Add desired Node platforms and build command to the "config" property in the `pa
 }
 ```
 
+- You can also specify a single file as a string for the `files` property.
+- If omitted, the `dir` property (ouptut directory) will default to `dist/`.
+
 Run the build step
 
     npm run build

--- a/bin/precompile.js
+++ b/bin/precompile.js
@@ -16,6 +16,19 @@ var config = pkg.config && pkg.config['pre-compiled']
 la(is.object(config),
   'missing pre-compiled config in package file', packageFilename)
 
+// convert a string "files" value to an array
+if (is.string(config.files)) {
+  config.files = [config.files]
+}
+
+// choose "dist" as default output directory
+if (is.not.unemptyString(config.dir)) {
+  config.dir = 'dist'
+}
+
+la(is.all(config, {dir: is.unemptyString, files: is.array}),
+  'invalid compiled config', config)
+
 var nodeFeatures = require('../features/get-features')()
 la(is.object(nodeFeatures), 'could not load node features')
 


### PR DESCRIPTION
These are just two changes that make pre-compiled a bit easier to use.

Due to the manner in which `pre-compiled` consumes `compiled`, I'm not able to just make the changes within `compiled` itself.  If you would like to see these in `compiled`, please let me know.

**UPDATE**: Added note to `README.md`.
